### PR TITLE
hotfix: automatically adjust nonce to time expected by server in case of error

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class Kucoin {
             err = obj
           }
 
-          this._timeAdjust = err && err.body && err.body.timestamp && err.body.timestamp - Date.now() || 0
+          this.adjustTimeFromError(err);
           deferred.reject(err)
         } else {
           deferred.resolve(obj)
@@ -88,6 +88,8 @@ class Kucoin {
           if (!err && !obj.success) {
             err = obj
           }
+
+          this.adjustTimeFromError(err);
           deferred.reject(err)
         } else {
           deferred.resolve(obj)
@@ -95,6 +97,16 @@ class Kucoin {
       })
     }
     return deferred.promise
+  }
+
+  /**
+   * Store time offset of expected time after an error happened
+   * to eliminate nonce errors for subsequent calls
+   * @access private
+   * @param {Object} err - the returned error object
+   */
+  adjustTimeFromError(err) {
+    this._timeAdjust = err && err.body && err.body.timestamp && err.body.timestamp - Date.now() || 0
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class Kucoin {
   rawRequest(method, endpoint, signed = false, params) {
     let deferred = Q.defer()
     let path = this.path_prefix + endpoint
-    let nonce = new Date().getTime()
+    let nonce = new Date().getTime() + (this._timeAdjust || 0)
     let queryString
     if (params !== undefined) {
       queryString = [];
@@ -75,6 +75,8 @@ class Kucoin {
           if (!err && !obj.success) {
             err = obj
           }
+
+          this._timeAdjust = err && err.body && err.body.timestamp && err.body.timestamp - Date.now() || 0
           deferred.reject(err)
         } else {
           deferred.resolve(obj)


### PR DESCRIPTION
sometimes the client time does not match / does not exactly match the expected time of the kucoin server. In this case we get back an `Invalid nonce` error from the kucoin api. This change will automatically adjust the nonce of subsequent calls to match the expected time if that happens

fixes https://github.com/Satoshinaire/kucoin-api/issues/6 (not for the first call, only for following calls)