### PR TITLE
Get all tickers error resolved

### DIFF
--- a/index.js
+++ b/index.js
@@ -680,7 +680,7 @@ class Kucoin {
    * }
    */
   getTicker(params = {}) {
-    return this.doRequest('get', '/' + params.pair + '/open/tick')
+    return this.doRequest('get', (params.pair ? ('/' + params.pair) : '') + '/open/tick')
   }
 
   /**


### PR DESCRIPTION
The code did not handle undefined `params.pair`, hence it used to generate "/undefined/open/tick" endpoint in line :683, resulting to an error instead of listing all tickers.
I added a condition to ckeck if the params.pair is undefined.